### PR TITLE
support bazel apt repo in dpkg_parser

### DIFF
--- a/package_manager/dpkg_parser.py
+++ b/package_manager/dpkg_parser.py
@@ -144,12 +144,21 @@ SHA1: 869934a25a8bb3def0f17fef9221bed2d3a460f9
 SHA256: 52ec3ac93cf8ba038fbcefe1e78f26ca1d59356cdc95e60f987c3f52b3f5e7ef
 
     """
-    url = "%s/debian/%s/dists/%s/main/binary-%s/Packages.gz" % (
-        mirror_url,
-        snapshot,
-        distro,
-        arch
-    )
+    url = ''
+    if snapshot !='':
+      url = "%s/debian/%s/dists/%s/main/binary-%s/Packages.gz" % (
+          mirror_url,
+          snapshot,
+          distro,
+          arch
+      )
+    else:
+      url = "%s/dists/%s/binary-%s/Packages.gz" % (
+          mirror_url,
+          distro,
+          arch
+      )
+
     buf = urllib2.urlopen(url)
     with open("Packages.gz", 'w') as f:
         f.write(buf.read())

--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -3,7 +3,7 @@ load(":dpkg.bzl", "dpkg_list", "dpkg_src")
 def package_manager_repositories():
   native.http_file(
       name = "dpkg_parser",
-      url = ('https://storage.googleapis.com/distroless/package_manager_tools/v0.5/dpkg_parser.par'),
+      url = ('https://storage.googleapis.com/asci-toolchain.appspot.com/dpkg_parser.par'),
       executable = True,
-      sha256 = "e008f56117eaf12c6a7e60c47901419fa84a458e4732387f04d2101bae5c7c95",
+      sha256 = "24e0b5307cd08100e03eb39b923e08a8761b3d711e9af1bd37e3251ac370c9ad",
   )

--- a/package_manager/parse_metadata.py
+++ b/package_manager/parse_metadata.py
@@ -54,5 +54,8 @@ def parse_package_metadata(data, mirror_url, snapshot):
     # Here, we're rewriting the metadata with the absolute urls,
     # which is a concatenation of the mirror + '/debian/' + relative_path
     for pkg_data in parsed_entries.itervalues():
-        pkg_data[FILENAME_KEY] = mirror_url + "/debian/" + snapshot + "/" + pkg_data[FILENAME_KEY]
+        if snapshot !='':
+          pkg_data[FILENAME_KEY] = mirror_url + "/debian/" + snapshot + "/" + pkg_data[FILENAME_KEY]
+        else:
+          pkg_data[FILENAME_KEY] = mirror_url + "/" + pkg_data[FILENAME_KEY]
     return parsed_entries


### PR DESCRIPTION
- cherry-pick commit from @nlopezgi , based on the latest distroless upstream
  https://github.com/nlopezgi/distroless/commit/505dc422321273206c247020de647688c6cb7f47

- rebuild dpkg_par.par so it contains the latest changes from upstream as well as change from @nlopezgi 