### PR TITLE
make repository_ctx.execute not quiet

### DIFF
--- a/package_manager/dpkg.bzl
+++ b/package_manager/dpkg.bzl
@@ -12,7 +12,7 @@ exports_files(deb_files + ["packages.bzl"])
       "--workspace-name", repository_ctx.name,
   ]
 
-  result = repository_ctx.execute(args)
+  result = repository_ctx.execute(args, quiet=False)
   if result.return_code:
     fail("dpkg_parser command failed: %s (%s)" % (result.stderr, " ".join(args)))
 
@@ -46,7 +46,7 @@ exports_files(["Packages.json", "os_release.tar"])
       "--sha256=" + repository_ctx.attr.sha256,
   ]
 
-  result = repository_ctx.execute(args)
+  result = repository_ctx.execute(args, quiet=False)
   if result.return_code:
     fail("dpkg_parser command failed: %s (%s)" % (result.stderr, " ".join(args)))
 

--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -5,5 +5,5 @@ def package_manager_repositories():
       name = "dpkg_parser",
       url = ("https://storage.googleapis.com/asci-toolchain.appspot.com/dpkg_parser/2017-10-24/dpkg_parser.par"),
       executable = True,
-      sha256 = "961111f57917fdfbd1052be16a7bb669a364d50d945bcfc69117e82235098d57",
+      sha256 = "b5f3e9c22ee9bc9b92e3b0b77da883f3854c9591f698cbba6eb495b14140e2bd",
   )


### PR DESCRIPTION
- by default repository_ctx.execute is quiet and will not output
  stdout / stderr. ref:
  https://docs.bazel.build/versions/master/skylark/lib/repository_ctx.html#exec

- we make execute `not quiet` for dpkg_parser related rules, so that we
  can use the debug information in the python scripts